### PR TITLE
fix: remove grid option from PostCssAutoprefixerPlugin

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -81,7 +81,7 @@ module.exports = merge(commonConfig, {
             options: {
               postcssOptions: {
                 plugins: [
-                  PostCssAutoprefixerPlugin({ grid: true }),
+                  PostCssAutoprefixerPlugin(),
                   PostCssRTLCSS(),
                 ],
               },

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -81,7 +81,7 @@ module.exports = merge(commonConfig, {
             options: {
               postcssOptions: {
                 plugins: [
-                  PostCssAutoprefixerPlugin({ grid: true }),
+                  PostCssAutoprefixerPlugin(),
                   PostCssRTLCSS(),
                 ],
               },

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -101,7 +101,7 @@ module.exports = merge(commonConfig, {
             options: {
               postcssOptions: {
                 plugins: [
-                  PostCssAutoprefixerPlugin({ grid: true }),
+                  PostCssAutoprefixerPlugin(),
                   PostCssRTLCSS(),
                   CssNano(),
                 ],


### PR DESCRIPTION
By default, `PostCssAutoprefixerPlugin` will not autoprefix `grid`-based properties, unless it is explicitly enabled, which we are doing in frontend-build's Webpack configs. As we no longer officially support older browsers like IE 11, we no longer have a need to autoprefix `grid` properties. More details about `grid` and autoprefixer may be found [here](https://github.com/postcss/autoprefixer#does-autoprefixer-polyfill-grid-layout-for-ie).

A new Paragon component (`SelectableBox`) utilizes the CSS `grid` properties, but when upgrading an MFE to the Paragon version with this new component, there are Webpack build warnings related to autoprefixer not supporting the `grid-auto-rows` property:

![image](https://user-images.githubusercontent.com/2828721/155522362-623a56cd-e97a-4410-977f-e43fd7ffb216.png)

In order for the MFE to build properly on this Paragon version is to have `grid` autoprefix explicitly disabled as we no longer have a need to support older browsers like IE 11 anymore.

With this change, MFEs using the aforementioned version of Paragon will build without warnings again.