### PR TITLE
fix: expand react peer dependency range to be compatible with `@edx/frontend-platform`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "fedx-scripts": "bin/fedx-scripts.js"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0"
+        "react": "^16.9.0 || ^17.0.0"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "webpack-merge": "5.2.0"
   },
   "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.0"
+    "react": "^16.9.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
`@edx/frontend-platform` currently denotes a `react` as a peer dependency at version 16.9.0, which other libraries in our frontend infrastructure specifies `react` as a peer dependency at version 16.12.0+:

https://github.com/openedx/frontend-platform/blob/master/package.json#L76

To avoid peer dependency conflicts when installing packages on Node 16 / NPM 8+, we should expand the `react` peer dependency range here to match what's currently expected by `@edx/frontend-platform`.