### PR TITLE
feat: Include OPTIMIZELY_PROJECT_ID in the HtmlWebpackPlugic dev config.

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -153,6 +153,7 @@ module.exports = merge(commonConfig, {
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(process.cwd(), 'public/index.html'),
       FAVICON_URL: process.env.FAVICON_URL || null,
+      OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
     }),
     new Dotenv({
       path: path.resolve(process.cwd(), '.env.development'),


### PR DESCRIPTION
This will allow dev environments to include the Optimizely script snippet via index.html,
which we know we need in at least two consuming MFEs.
This should be fine for any downstream consumers that don't use Optimizely, because
we tend to conditionally include an Optimizely script in index.html based on the existence of
an OPTIMIZELY_PROJECT_ID variable in the environment (i.e. in `.env.development`). So if
that variable is not present by default (which it shouldn't be), no Optimizely script is included.

Example downstream consumers that want this:
* enterprise admin-portal
* enterprise learner-portal
* relevant ticket: https://openedx.atlassian.net/browse/ENT-5726