### PR TITLE
feat: upgrade @edx/eslint-config to lint React Hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@babel/plugin-syntax-dynamic-import": "7.8.3",
         "@babel/preset-env": "7.16.4",
         "@babel/preset-react": "7.16.0",
-        "@edx/eslint-config": "2.0.0",
+        "@edx/eslint-config": "3.0.0",
         "@edx/new-relic-source-map-webpack-plugin": "1.0.1",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.3",
         "@svgr/webpack": "6.2.1",
@@ -1779,9 +1779,9 @@
       }
     },
     "node_modules/@edx/eslint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-2.0.0.tgz",
-      "integrity": "sha512-JfbN9kTs6qWNzNL0+GTbifHktXXpe6oPXXEy7jA6FykzD51FcGBPIp88v3AtHgfaoMnD95He3SATdeNCRIjcqQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-3.0.0.tgz",
+      "integrity": "sha512-3vMX3/vqYxpJK/XKGRjWlsvcIkOQYMxJ1uXcVl70HiQda31xWW4qpg2OTevEdnYo5vThSBVMFe7lRmMpMNDR7Q==",
       "peerDependencies": {
         "eslint": "^6.8.0 || ^7.0.0 || ^8.0.0",
         "eslint-config-airbnb": "^18.0.1 || ^19.0.0",
@@ -3867,9 +3867,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -20453,9 +20453,9 @@
       "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA=="
     },
     "@edx/eslint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-2.0.0.tgz",
-      "integrity": "sha512-JfbN9kTs6qWNzNL0+GTbifHktXXpe6oPXXEy7jA6FykzD51FcGBPIp88v3AtHgfaoMnD95He3SATdeNCRIjcqQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-3.0.0.tgz",
+      "integrity": "sha512-3vMX3/vqYxpJK/XKGRjWlsvcIkOQYMxJ1uXcVl70HiQda31xWW4qpg2OTevEdnYo5vThSBVMFe7lRmMpMNDR7Q==",
       "requires": {}
     },
     "@edx/new-relic-source-map-webpack-plugin": {
@@ -22032,9 +22032,9 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/preset-env": "7.16.4",
     "@babel/preset-react": "7.16.0",
-    "@edx/eslint-config": "2.0.0",
+    "@edx/eslint-config": "3.0.0",
     "@edx/new-relic-source-map-webpack-plugin": "1.0.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.3",
     "@svgr/webpack": "6.2.1",


### PR DESCRIPTION
BREAKING CHANGE: By upgrading to `@edx/eslint-config` v3, we will start extending `airbnb/hooks` and consumers of this library will now get ESLint errors about React Hooks:

1. Rules of Hooks.
2. Exhaustive dependencies.

See https://github.com/airbnb/javascript/blob/fdc812a0a5773449274f7c4d473e0841eca89614/packages/eslint-config-airbnb/rules/react-hooks.js for more details.