### PR TITLE
feat/ disableDotRule in dev mode

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -168,6 +168,7 @@ module.exports = merge(commonConfig, {
     host: '0.0.0.0',
     port: process.env.PORT || 8080,
     historyApiFallback: {
+      disableDotRule: true,
       index: path.join(PUBLIC_PATH, 'index.html'),
     },
     // Enable hot reloading server. It will provide WDS_SOCKET_PATH endpoint


### PR DESCRIPTION
Sometime we have course with dot in the course code (i.e WEB101x_2,.1) so we should disable dot rule in webpack to allow . in route for MFE.