### PR TITLE
fix: added updated fedx-scripts eslint path

### DIFF
--- a/bin/fedx-scripts.js
+++ b/bin/fedx-scripts.js
@@ -50,6 +50,7 @@ switch (commandName) {
     break;
   case 'eslint':
     ensureConfigOption(presets.eslint);
+    require('eslint/bin/eslint');
     break;
   case 'jest':
     ensureConfigOption(presets.jest);

--- a/bin/fedx-scripts.js
+++ b/bin/fedx-scripts.js
@@ -50,7 +50,8 @@ switch (commandName) {
     break;
   case 'eslint':
     ensureConfigOption(presets.eslint);
-    require('eslint/bin/eslint');
+    // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
+    require('.bin/eslint');
     break;
   case 'jest':
     ensureConfigOption(presets.jest);


### PR DESCRIPTION
**Ticket:** 
[@edx/frontend-build v12+ is not properly linting with eslint](https://github.com/openedx/frontend-wg/issues/114)

**What has changed:**
- Updated `fedx-scripts`, to require `eslint` in order to resolve `linting` issues on consumer side. [Previously we were using `'eslint/bin/eslint'` to load eslint in `fedx-scripts `but with v8 upgrade that failed. Beginning with v8.0.0, ESLint is strictly defining its public API. Previously, we could reach into individual files such as require("eslint/bin/eslint") but this is no longer allowed]