### PR TITLE
Ignored eslint for module.config.js

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -37,4 +37,7 @@ module.exports = {
   globals: {
     newrelic: false,
   },
+  ignorePatterns: [
+    'module.config.js',
+  ],
 };


### PR DESCRIPTION
**Ticket:**
[115: ignore ESLint for `module.config.js` file](https://github.com/openedx/frontend-wg/issues/115)

**What changed?**
- Ignored ESLint for `module.config.js` file.