### PR TITLE
chore: update linting rules to prevent warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,5 +6,7 @@ module.exports = createConfig('eslint', {
     'import/no-dynamic-require': 'off',
     'global-require': 'off',
     'no-template-curly-in-string': 'off',
+    'import/no-import-module-export': 'off',
+    'react/function-component-definition': [2, { namedComponents: 'arrow-function' }],
   },
 });


### PR DESCRIPTION
When we updated eslint to v8, more rules were added by default. This turns off rules that we don't want. It also forces arrow function syntax for functional react components.