### PR TITLE
feat: add new accepted linting rules for functional components and module imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,5 +6,7 @@ module.exports = createConfig('eslint', {
     'import/no-dynamic-require': 'off',
     'global-require': 'off',
     'no-template-curly-in-string': 'off',
+    'import/no-import-module-export': 'off',
+    'react/function-component-definition': [2, { namedComponents: 'arrow-function' }],
   },
 });


### PR DESCRIPTION
We've added rules to force repo consistency for functional components, and have turned off rules around module import warnings.

If you decide arrow functions aren't right for your particular project, feel free to override them, and keep your repo consistent with named functions. Override guidance is in the README of this repo, and I will be creating a comment about this decision for the cookie cutter template.