### PR TITLE
fix: remove messagesDir for babel-react-intl 8

### DIFF
--- a/config/babel-preserve-modules.config.js
+++ b/config/babel-preserve-modules.config.js
@@ -19,7 +19,6 @@ module.exports = {
         [
           'react-intl',
           {
-            messagesDir: './temp/babel-plugin-react-intl',
             moduleSourceName: '@edx/frontend-platform/i18n',
           },
         ],

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -35,7 +35,6 @@ module.exports = {
         [
           'react-intl',
           {
-            messagesDir: './temp/babel-plugin-react-intl',
             moduleSourceName: '@edx/frontend-platform/i18n',
           },
         ],


### PR DESCRIPTION
The support for `messageDir` has been drop. https://github.com/formatjs/formatjs/commit/47ca556c1405eec7b7b2660275ae84a019112b2b

There should be a future plan use `babel-plugin-formatjs` instead because `babel-react-intl` has already been archived and moved.
