### PR TITLE
Revert "fix(deps): update dependency babel-plugin-react-intl to v8"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "autoprefixer": "10.4.13",
         "babel-jest": "26.6.3",
         "babel-loader": "8.2.3",
-        "babel-plugin-react-intl": "8.2.25",
+        "babel-plugin-react-intl": "7.9.4",
         "babel-plugin-transform-imports": "2.0.0",
         "babel-polyfill": "6.26.0",
         "clean-webpack-plugin": "3.0.0",
@@ -1883,10 +1883,19 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.0.tgz",
-      "integrity": "sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.4.0.tgz",
+      "integrity": "sha512-Mv027hcLFjE45K8UJ8PjRpdDGfR0aManEFj1KzoN8zXNveHGEygpZGfFf/FTTMl+QEVSrPAUlyxaCApvmv47AQ==",
       "dependencies": {
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@formatjs/intl-numberformat": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.7.6.tgz",
+      "integrity": "sha512-ZlZfYtvbVHYZY5OG3RXizoCwxKxEKOrzEe2YOw9wbzoxF3PmFn0SAgojCFGLyNXkkR6xVxlylhbuOPf1dkIVNg==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.4.0",
         "tslib": "^2.0.1"
       }
     },
@@ -1906,6 +1915,24 @@
         "ts-jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.0.tgz",
+      "integrity": "sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/intl-messageformat-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-6.1.2.tgz",
+      "integrity": "sha512-4GQDEPhl/ZMNDKwMsLqyw1LG2IAWjmLJXdmnRcHKeLQzpgtNYZI6lVw1279pqIkRk2MfKb9aDsVFzm565azK5A==",
+      "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.5.0",
+        "tslib": "^2.0.1"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3199,6 +3226,14 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -4336,20 +4371,38 @@
       }
     },
     "node_modules/babel-plugin-react-intl": {
-      "version": "8.2.25",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-intl/-/babel-plugin-react-intl-8.2.25.tgz",
-      "integrity": "sha512-vqzRwqxMKHBKEpzWIIabxUXSBYd8urOkk49nQdzgEt55tLIuDc1XdHceeMNaeJt9VRLYZUiL5vpYpnvrntUNMQ==",
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-intl/-/babel-plugin-react-intl-7.9.4.tgz",
+      "integrity": "sha512-cMKrHEXrw43yT4M89Wbgq8A8N8lffSquj1Piwov/HVukR7jwOw8gf9btXNsQhT27ccyqEwy+M286JQYy0jby2g==",
       "deprecated": "this package has been renamed to babel-plugin-formatjs",
       "dependencies": {
         "@babel/core": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/types": "^7.9.5",
-        "@formatjs/ts-transformer": "2.13.0",
+        "@formatjs/ts-transformer": "^2.6.0",
         "@types/babel__core": "^7.1.7",
+        "@types/fs-extra": "^9.0.1",
         "@types/schema-utils": "^2.4.0",
-        "intl-messageformat-parser": "6.1.2",
-        "schema-utils": "^3.0.0",
-        "tslib": "^2.0.1"
+        "fs-extra": "^9.0.0",
+        "intl-messageformat-parser": "^5.3.7",
+        "schema-utils": "^2.6.6"
+      }
+    },
+    "node_modules/babel-plugin-react-intl/node_modules/schema-utils": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+      "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.5",
+        "ajv": "^6.12.4",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/babel-plugin-transform-imports": {
@@ -8670,13 +8723,12 @@
       }
     },
     "node_modules/intl-messageformat-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-6.1.2.tgz",
-      "integrity": "sha512-4GQDEPhl/ZMNDKwMsLqyw1LG2IAWjmLJXdmnRcHKeLQzpgtNYZI6lVw1279pqIkRk2MfKb9aDsVFzm565azK5A==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.5.1.tgz",
+      "integrity": "sha512-TvB3LqF2VtP6yI6HXlRT5TxX98HKha6hCcrg9dwlPwNaedVNuQA9KgBdtWKgiyakyCTYHQ+KJeFEstNKfZr64w==",
       "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.5.0",
-        "tslib": "^2.0.1"
+        "@formatjs/intl-numberformat": "^5.5.2"
       }
     },
     "node_modules/ip": {
@@ -18098,10 +18150,19 @@
       }
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.0.tgz",
-      "integrity": "sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.4.0.tgz",
+      "integrity": "sha512-Mv027hcLFjE45K8UJ8PjRpdDGfR0aManEFj1KzoN8zXNveHGEygpZGfFf/FTTMl+QEVSrPAUlyxaCApvmv47AQ==",
       "requires": {
+        "tslib": "^2.0.1"
+      }
+    },
+    "@formatjs/intl-numberformat": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.7.6.tgz",
+      "integrity": "sha512-ZlZfYtvbVHYZY5OG3RXizoCwxKxEKOrzEe2YOw9wbzoxF3PmFn0SAgojCFGLyNXkkR6xVxlylhbuOPf1dkIVNg==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.4.0",
         "tslib": "^2.0.1"
       }
     },
@@ -18113,6 +18174,25 @@
         "intl-messageformat-parser": "6.1.2",
         "tslib": "^2.0.1",
         "typescript": "^4.0"
+      },
+      "dependencies": {
+        "@formatjs/ecma402-abstract": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.0.tgz",
+          "integrity": "sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==",
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
+        "intl-messageformat-parser": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-6.1.2.tgz",
+          "integrity": "sha512-4GQDEPhl/ZMNDKwMsLqyw1LG2IAWjmLJXdmnRcHKeLQzpgtNYZI6lVw1279pqIkRk2MfKb9aDsVFzm565azK5A==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.5.0",
+            "tslib": "^2.0.1"
+          }
+        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -19030,6 +19110,14 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -19941,19 +20029,32 @@
       }
     },
     "babel-plugin-react-intl": {
-      "version": "8.2.25",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-intl/-/babel-plugin-react-intl-8.2.25.tgz",
-      "integrity": "sha512-vqzRwqxMKHBKEpzWIIabxUXSBYd8urOkk49nQdzgEt55tLIuDc1XdHceeMNaeJt9VRLYZUiL5vpYpnvrntUNMQ==",
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-intl/-/babel-plugin-react-intl-7.9.4.tgz",
+      "integrity": "sha512-cMKrHEXrw43yT4M89Wbgq8A8N8lffSquj1Piwov/HVukR7jwOw8gf9btXNsQhT27ccyqEwy+M286JQYy0jby2g==",
       "requires": {
         "@babel/core": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/types": "^7.9.5",
-        "@formatjs/ts-transformer": "2.13.0",
+        "@formatjs/ts-transformer": "^2.6.0",
         "@types/babel__core": "^7.1.7",
+        "@types/fs-extra": "^9.0.1",
         "@types/schema-utils": "^2.4.0",
-        "intl-messageformat-parser": "6.1.2",
-        "schema-utils": "^3.0.0",
-        "tslib": "^2.0.1"
+        "fs-extra": "^9.0.0",
+        "intl-messageformat-parser": "^5.3.7",
+        "schema-utils": "^2.6.6"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+          "requires": {
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "babel-plugin-transform-imports": {
@@ -23120,12 +23221,11 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
     },
     "intl-messageformat-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-6.1.2.tgz",
-      "integrity": "sha512-4GQDEPhl/ZMNDKwMsLqyw1LG2IAWjmLJXdmnRcHKeLQzpgtNYZI6lVw1279pqIkRk2MfKb9aDsVFzm565azK5A==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.5.1.tgz",
+      "integrity": "sha512-TvB3LqF2VtP6yI6HXlRT5TxX98HKha6hCcrg9dwlPwNaedVNuQA9KgBdtWKgiyakyCTYHQ+KJeFEstNKfZr64w==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.5.0",
-        "tslib": "^2.0.1"
+        "@formatjs/intl-numberformat": "^5.5.2"
       }
     },
     "ip": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "autoprefixer": "10.4.13",
     "babel-jest": "26.6.3",
     "babel-loader": "8.2.3",
-    "babel-plugin-react-intl": "8.2.25",
+    "babel-plugin-react-intl": "7.9.4",
     "babel-plugin-transform-imports": "2.0.0",
     "babel-polyfill": "6.26.0",
     "clean-webpack-plugin": "3.0.0",


### PR DESCRIPTION
There is a breaking change that affect us. https://github.com/formatjs/formatjs/commit/47ca556c1405eec7b7b2660275ae84a019112b2b

`messageDir` is being remove. There is also a desire to remove replace `babel-plugin-react-intl` with `babel-plugin-formatjs`.  https://github.com/openedx/frontend-wg/issues/120

Reverts openedx/frontend-build#116