### PR TITLE
build: add github action workflow to auto-sync master to alpha

### DIFF
--- a/.github/workflows/sync-master-alpha.yml
+++ b/.github/workflows/sync-master-alpha.yml
@@ -1,0 +1,30 @@
+name: Sync alpha with master
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+      - name: Create Pull Request
+        id: cpr
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.requirements_bot_github_token }}
+          FROM_BRANCH: master
+          TO_BRANCH: alpha
+      - name: Enable Pull Request Automerge
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.requirements_bot_github_token }}
+          pull-request-number: ${{ steps.cpr.outputs.PULL_REQUEST_NUMBER }}


### PR DESCRIPTION
As we are introducing an `alpha` distribution of `@edx/frontend-build`, it will be helpful to have automation in place to sync changes to `master` with the `alpha` branch so the `alpha` branch doesn't get quickly outdated.

The intent is to have the generated PR  auto-merged to bring changes from `master` to `alpha` automatically.

I changed the Settings for this repo to enable auto-merge and added a branch protection rule to `alpha` branch.