### PR TITLE
fix: disable dot rule in historyApiFallback in webpack.dev.config.js files.

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -173,6 +173,7 @@ module.exports = merge(commonConfig, {
     https: true,
     historyApiFallback: {
       index: path.join(PUBLIC_PATH, 'index.html'),
+      disableDotRule: true,
     },
     // Enable hot reloading server. It will provide WDS_SOCKET_PATH endpoint
     // for the WebpackDevServer client so it can learn when the files were

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -175,6 +175,7 @@ module.exports = merge(commonConfig, {
     port: process.env.PORT || 8080,
     historyApiFallback: {
       index: path.join(PUBLIC_PATH, 'index.html'),
+      disableDotRule: true,
     },
     // Enable hot reloading server. It will provide WDS_SOCKET_PATH endpoint
     // for the WebpackDevServer client so it can learn when the files were


### PR DESCRIPTION
Ran into this issue trying to use an MFE route that contains a course key with a period (e.g., `MITx+CTL.SC2x`) in two different MFEs relying on standard development webpack configs from `@edx/frontend-build`:

<img width="509" alt="image" src="https://user-images.githubusercontent.com/2828721/235788018-10144848-ee85-4296-9853-47034151a589.png">

This PR sets `disableDotRule: true` for the `historyApiFallback` configuration to make it possible to load MFE routes with a period (`.`) in them without issue.

Docs: https://github.com/bripkens/connect-history-api-fallback#disabledotrule