### PR TITLE
feat: reduce build time with cache

### DIFF
--- a/lib/ConfigPreset.js
+++ b/lib/ConfigPreset.js
@@ -12,6 +12,7 @@ function ConfigPreset({
   return {
     defaultFilename,
     getDefault: () => require(require.resolve(`./${defaultFilename}`, { paths: [defaultDir] })),
+    getMfePath: () => searchFilepaths[0],
     get defaultFilepath() {
       console.log('getting default filepath', defaultFilename, defaultDir);
       return require.resolve(`./${defaultFilename}`, { paths: [defaultDir] });

--- a/lib/createConfig.js
+++ b/lib/createConfig.js
@@ -1,7 +1,28 @@
 const { merge } = require('webpack-merge');
+const path = require('path');
 const getBaseConfig = require('./getBaseConfig');
+const mfePath = require('./mfePath');
 
 module.exports = (commandName, configFragment = {}) => {
   const baseConfig = getBaseConfig(commandName);
+
+  if (commandName === 'webpack-prod') {
+    const { path: cachePath } = mfePath;
+    baseConfig.cache = {
+      type: 'filesystem',
+      cacheDirectory: path.resolve(cachePath, '.cache'),
+    };
+
+    const ignorePlugins = ['NewRelicPlugin', 'HtmlWebpackNewRelicPlugin', 'BundleAnalyzerPlugin'];
+
+    const { plugins } = baseConfig;
+
+    baseConfig.plugins = plugins.filter((plugin) => !ignorePlugins.includes(plugin.constructor.name));
+
+    baseConfig.devtool = false;
+
+    return merge(baseConfig, configFragment);
+  }
+
   return merge(baseConfig, configFragment);
 };

--- a/lib/getBaseConfig.js
+++ b/lib/getBaseConfig.js
@@ -1,8 +1,13 @@
 const presets = require('./presets');
+const mfePath = require('./mfePath');
 
 module.exports = (commandName) => {
   if (presets[commandName] === undefined) {
     throw new Error(`fedx-scripts: ${commandName} is unsupported in this version`);
+  }
+
+  if (commandName === 'webpack-prod') {
+    mfePath.path = presets[commandName].getMfePath();
   }
 
   return presets[commandName].getDefault();

--- a/lib/mfePath.js
+++ b/lib/mfePath.js
@@ -1,0 +1,5 @@
+const mfePath = {
+  path: __dirname,
+};
+
+module.exports = mfePath;


### PR DESCRIPTION
Most MFEs are using @edx/frontend-build to build their static files for both production and development configurations. However, this setup only works effectively for production because it ignores certain Webpack plugins that are unnecessary in a production environment.

This proposed change aims to enhance the build time for production by optimizing the Webpack cache configuration. It results in a significant improvement, with build times becoming more than 80% faster.

Issue related: https://github.com/overhangio/tutor-mfe/issues/88

No cache          |  Cached
:-------------------------:|:-------------------------:
![webpack-build-no-cache](https://github.com/openedx/frontend-build/assets/134975835/bdb05084-a8a7-4c01-bb2f-919903c50055)  |  ![webpack-build-cache](https://github.com/openedx/frontend-build/assets/134975835/c65d9a61-9911-474f-b592-677b0be26547)




<table>
  <tr>
    <th colspan="3">No cache</th>
    <th colspan="3">Cached</th>
  </tr>
  <tr>
    <th>ms</th>
    <th>seconds</th>
    <th>minutes</th>
    <th>ms</th>
    <th>seconds</th>
    <th>minutes</th>
  </tr>
  <tr>
    <td>109849</td>
    <td>109,849</td>
    <td>1,83</td>
    <td>3988</td>
    <td>3,988</td>
    <td>0,06</td>
  </tr>
</table>

**Note:** We may need to add a volume in tutor to the .cache folder for each MFE and introduce an additional configuration to enable or disable this feature within tutor
