### PR TITLE
fix: ensure .env.development PORT works

### DIFF
--- a/lib/scripts/serve.js
+++ b/lib/scripts/serve.js
@@ -40,13 +40,15 @@ if (isDirectoryEmpty(buildPath)) {
   console.log(chalk.bold.red(`ERROR: No build found. Please run ${formattedBuildCmd} first.`));
 } else {
   let configuredPort;
-  let envConfig;
 
   try {
-    envConfig = require(path.join(process.cwd(), 'env.config.js'));
-    configuredPort = envConfig?.PORT || process.env.PORT;
+    configuredPort = require(path.join(process.cwd(), 'env.config.js'))?.PORT;
   } catch (error) {
-    // pass, consuming applications may not have an `env.config.js` file. This is OK.
+    // Pass. Consuming applications may not have an `env.config.js` file. This is OK.
+  }
+
+  if (!configuredPort) {
+    configuredPort = process.env.PORT;
   }
 
   // No `PORT` found in `env.config.js` and/or `.env.development|private`, so output a warning.


### PR DESCRIPTION
When upgrading to the latest version of frontend-build in an Enterprise MFE, the server port was not detecting the port in the .env.development file as expected... this PR ensures it should run on the expected `PORT`.