### PR TITLE
fix: silence sass compiler warnings about Dart Sass deprecations

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -100,6 +100,8 @@ module.exports = merge(commonConfig, {
                   path.join(process.cwd(), 'node_modules'),
                   path.join(process.cwd(), 'src'),
                 ],
+                // silences compiler warnings regarding deprecation warnings
+                quietDeps: true,
               },
             },
           },

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -101,6 +101,8 @@ module.exports = merge(commonConfig, {
                   path.join(process.cwd(), 'node_modules'),
                   path.join(process.cwd(), 'src'),
                 ],
+                // silences compiler warnings regarding deprecation warnings
+                quietDeps: true,
               },
             },
           },

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -131,6 +131,8 @@ module.exports = merge(commonConfig, {
                   path.join(process.cwd(), 'node_modules'),
                   path.join(process.cwd(), 'src'),
                 ],
+                // silences compiler warnings regarding deprecation warnings
+                quietDeps: true,
               },
             },
           },


### PR DESCRIPTION
https://sass-lang.com/documentation/js-api/interfaces/options/#quietDeps

> If this option is set to true, Sass won’t print warnings that are caused by dependencies. A “dependency” is defined as any file that’s loaded through [loadPaths](https://sass-lang.com/documentation/js-api/interfaces/Options#loadPaths) or [importers](https://sass-lang.com/documentation/js-api/interfaces/Options#importers). Stylesheets that are imported relative to the entrypoint are not considered dependencies.

https://github.com/twbs/bootstrap/issues/34051

Example deprecation warnings seen throughout MFEs (common issue):

```
WARNING in ./src/index.scss (./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./node_modules/resolve-url-loader/index.js!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[1].use[4]!./src/index.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(2em, 14) or calc(2em / 14)

More info and automated migrator: https://sass-lang.com/d/slash-div

node_modules/font-awesome/scss/_list.scss 14:9         @import
node_modules/font-awesome/scss/font-awesome.scss 12:9  @import
src/index.scss 9:9                                     root stylesheet

 @ ./src/index.scss 8:6-311 22:17-24 26:7-21 52:25-39 53:36-47 53:50-64 57:6-67:7 58:54-65 58:68-82 64:42-53 64:56-70 66:21-28 77:0-281 77:0-281 78:22-29 78:33-47 78:50-64 55:4-68:5
 @ ./src/index.jsx 14:0-22
```

![image](https://github.com/openedx/frontend-build/assets/2828721/005c9cde-e0a3-4aeb-8db0-4463cb09a574)
