### PR TITLE
fix: errors generated by source maps loader

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -19,4 +19,22 @@ module.exports = {
     },
     extensions: ['.js', '.jsx'],
   },
+  ignoreWarnings: [
+    // Ignore warnings raised by source-map-loader.
+    // some third party packages may ship miss-configured sourcemaps, that interrupts the build
+    // See: https://github.com/facebook/create-react-app/discussions/11278#discussioncomment-1780169
+    /**
+     *
+     * @param {import('webpack').WebpackError} warning
+     * @returns {boolean}
+     */
+    function ignoreSourcemapsloaderWarnings(warning) {
+      return (
+        warning.module
+        && warning.module.resource.includes('node_modules')
+        && warning.details
+        && warning.details.includes('source-map-loader')
+      );
+    },
+  ],
 };


### PR DESCRIPTION
## Description
This PR fixes errors generated by source-maps-loader for some packages.
Careful consideration is taken to only ignore issues generated by node modules as some third party packages may ship miss-configured sourcemaps, that interrupts the build.
See: https://github.com/facebook/create-react-app/discussions/11278#discussioncomment-1780169 and https://github.com/facebook/create-react-app/pull/11752


## Supporting information
This PR fixes https://github.com/openedx/paragon/issues/1674


## Testing instructions
On running `npm run build` on any of the MFE's you would have an error similar to the below 
![image](https://github.com/openedx/frontend-build/assets/17045858/2e9a9fbd-c5aa-4aea-b8c9-01bff4dd1551)
The error to look out for here is `Failed to parse source map`
After this fix the error should be gone and not show up on running `npm run build`.
Some MFE's have multiple of these errors and should be gone also.


Fixes: https://github.com/openedx/paragon/issues/1674
Private-ref: https://tasks.opencraft.com/browse/BB-7705