### PR TITLE
fix: install ts-jest as dev dependency to ensure winds up in consuming bin files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
         "sharp": "^0.32.0",
         "source-map-loader": "^4.0.1",
         "style-loader": "3.3.3",
-        "ts-jest": "^26.5.0",
         "typescript": "^4.9.4",
         "url-loader": "4.1.1",
         "webpack": "5.88.2",
@@ -79,7 +78,8 @@
       "devDependencies": {
         "@babel/preset-typescript": "^7.18.6",
         "@types/react": "^17.0.0",
-        "@types/react-dom": "^17.0.11"
+        "@types/react-dom": "^17.0.11",
+        "ts-jest": "^26.5.0"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0"
@@ -4919,6 +4919,7 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
       "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "devOptional": true,
       "dependencies": {
         "fast-json-stable-stringify": "2.x"
       },
@@ -10492,7 +10493,8 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -10692,6 +10694,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "devOptional": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -15020,6 +15023,7 @@
       "version": "26.5.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.6.tgz",
       "integrity": "sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==",
+      "devOptional": true,
       "dependencies": {
         "bs-logger": "0.x",
         "buffer-from": "1.x",
@@ -15047,6 +15051,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "devOptional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -15058,6 +15063,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "devOptional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -15071,7 +15077,8 @@
     "node_modules/ts-jest/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "devOptional": true
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "sass-loader": "13.3.2",
     "sharp": "^0.32.0",
     "source-map-loader": "^4.0.1",
-    "ts-jest": "^26.5.0",
     "style-loader": "3.3.3",
     "typescript": "^4.9.4",
     "url-loader": "4.1.1",
@@ -95,6 +94,7 @@
     "webpack-merge": "5.9.0"
   },
   "devDependencies": {
+    "ts-jest": "^26.5.0",
     "@babel/preset-typescript": "^7.18.6",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.11"


### PR DESCRIPTION
Move ts-jest to devDependencies.  This seems to allow the install step to put it in node_modules/.bin even when installed as a dependency, which is necessary to allow the jest config to work.