### PR TITLE
feat: Oep65: Add Piral and Pilet webpack configuration

### DIFF
--- a/config/webpack.pilet.config.js
+++ b/config/webpack.pilet.config.js
@@ -1,0 +1,162 @@
+/**
+ * This webpack config is derived from the OpenEdx prod webpack config and is
+ * used to bundle the Open Edx pilets. It removes the ReactRefreshWebpackPlugin
+ * as it was conflicting with Piral during bundling. It als remoes the HTMLWebpack
+ * plugin as Pilets, unlike MFE's, are not independently run.
+ */
+
+// This is the prod Webpack config. All settings here should prefer smaller,
+// optimized bundles at the expense of a longer build time.
+const ImageMinimizerPlugin = require('image-minimizer-webpack-plugin');
+
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const { merge } = require('webpack-merge');
+const Dotenv = require('dotenv-webpack');
+const dotenv = require('dotenv');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const PostCssAutoprefixerPlugin = require('autoprefixer');
+const PostCssRTLCSS = require('postcss-rtlcss');
+const PostCssCustomMediaCSS = require('postcss-custom-media');
+const path = require('path');
+const getLocalAliases = require('./getLocalAliases');
+
+const commonConfig = require('./webpack.common.config');
+
+const presets = require('../lib/presets');
+
+delete commonConfig.entry;
+delete commonConfig.output;
+
+// Add process env vars. Currently used only for setting the PUBLIC_PATH.
+dotenv.config({
+  path: path.resolve(process.cwd(), '.env.development'),
+});
+
+const aliases = getLocalAliases();
+
+const mode = process.env.NODE_ENV === 'development' ? 'development' : 'production';
+
+module.exports = merge(commonConfig, {
+  // eslint-disable-next-line object-shorthand
+  mode: mode,
+  devtool: 'eval-source-map',
+  resolve: {
+    alias: aliases,
+    extensions: ['.js', '.jsx', '.ts', '.tsx'],
+  },
+  module: {
+    // Specify file-by-file rules to Webpack. Some file-types need a particular kind of loader.
+    rules: [
+      // The babel-loader transforms newer ES2015+ syntax to older ES5 for older browsers.
+      // Babel is configured with the .babelrc file at the root of the project.
+      {
+        test: /\.(js|jsx|ts|tsx)$/,
+        exclude: /node_modules\/(?!@edx)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            configFile: presets['babel-typescript'].resolvedFilepath,
+          },
+        },
+      },
+      {
+        test: /(.scss|.css)$/,
+        use: [
+          'style-loader', // creates style nodes from JS strings
+          {
+            loader: 'css-loader', // translates CSS into CommonJS
+            options: {
+              sourceMap: true,
+              modules: {
+                compileType: 'icss',
+              },
+            },
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              postcssOptions: {
+                plugins: [
+                  PostCssAutoprefixerPlugin(),
+                  PostCssRTLCSS(),
+                  PostCssCustomMediaCSS(),
+                ],
+              },
+            },
+          },
+          'resolve-url-loader',
+          {
+            loader: 'sass-loader', // compiles Sass to CSS
+            options: {
+              sourceMap: true,
+              sassOptions: {
+                includePaths: [
+                  path.join(process.cwd(), 'node_modules'),
+                  path.join(process.cwd(), 'src'),
+                ],
+              },
+            },
+          },
+        ],
+      },
+      {
+        test: /.svg(\?v=\d+\.\d+\.\d+)?$/,
+        issuer: /\.jsx?$/,
+        use: ['@svgr/webpack'],
+      },
+      // Webpack, by default, uses the url-loader for images and fonts that are required/included by
+      // files it processes, which just base64 encodes them and inlines them in the javascript
+      // bundles. This makes the javascript bundles ginormous and defeats caching so we will use the
+      // file-loader instead to copy the files directly to the output directory.
+      {
+        test: /\.(woff2?|ttf|svg|eot)(\?v=\d+\.\d+\.\d+)?$/,
+        loader: 'file-loader',
+      },
+      {
+        test: /favicon.ico$/,
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]', // <-- retain original file name
+        },
+      },
+      {
+        test: /\.(jpe?g|png|gif)(\?v=\d+\.\d+\.\d+)?$/,
+        loader: 'file-loader',
+      },
+
+    ],
+  },
+  optimization: {
+    minimizer: [
+      '...',
+      new ImageMinimizerPlugin({
+        minimizer: {
+          implementation: ImageMinimizerPlugin.sharpMinify,
+          options: {
+            encodeOptions: {
+              ...['png', 'jpeg', 'jpg'].reduce((accumulator, value) => (
+                { ...accumulator, [value]: { progressive: true, quality: 65 } }
+              ), {}),
+              gif: {
+                effort: 5,
+              },
+            },
+          },
+        },
+      }),
+    ],
+  },
+  // Specify additional processing or side-effects done on the Webpack output bundles as a whole.
+  plugins: [
+    // Cleans the dist directory before each build
+    new CleanWebpackPlugin(),
+    // Writes the extracted CSS from each entry to a file in the output directory.
+    new MiniCssExtractPlugin({
+      filename: '[name].[chunkhash].css',
+    }),
+    new Dotenv({
+      path: path.resolve(process.cwd(), '.env.development'),
+      systemvars: true,
+    }),
+  ],
+});

--- a/config/webpack.piral.config.js
+++ b/config/webpack.piral.config.js
@@ -1,0 +1,58 @@
+/**
+ * This webpack config is derived from the OpenEdx dev webpack config and is
+ * used to bundle the Open Edx Piral shell. It removes babel and other loader
+ * configs as those are not necessary for the simple layouts used in the shell.
+ */
+
+// This is the dev Webpack config. All settings here should prefer a fast build
+// time at the expense of creating larger, unoptimized bundles.
+const { merge } = require('webpack-merge');
+const Dotenv = require('dotenv-webpack');
+const dotenv = require('dotenv');
+const path = require('path');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const commonConfig = require('./webpack.common.config');
+const resolvePrivateEnvConfig = require('../lib/resolvePrivateEnvConfig');
+const getLocalAliases = require('./getLocalAliases');
+
+// Add process env vars. Currently used only for setting the
+// server port and the publicPath
+dotenv.config({
+  path: path.resolve(process.cwd(), '.env.development'),
+});
+
+// Allow private/local overrides of env vars from .env.development for config settings
+// that you'd like to persist locally during development, without the risk of checking
+// in temporary modifications to .env.development.
+resolvePrivateEnvConfig('.env.private');
+
+const aliases = getLocalAliases();
+const PUBLIC_PATH = process.env.PUBLIC_PATH || '/';
+const mode = process.env.NODE_ENV === 'development' ? 'development' : 'production';
+
+module.exports = merge(commonConfig, {
+  // eslint-disable-next-line object-shorthand
+  mode: mode,
+  devtool: 'eval-source-map',
+  output: {
+    publicPath: PUBLIC_PATH,
+  },
+  resolve: {
+    alias: aliases,
+    extensions: ['.js', '.jsx', '.ts', '.tsx'],
+  },
+
+  // Specify additional processing or side-effects done on the Webpack output bundles as a whole.
+  plugins: [
+    new Dotenv({
+      path: path.resolve(process.cwd(), '.env.development'),
+      systemvars: true,
+    }),
+    new ReactRefreshWebpackPlugin(),
+    new MiniCssExtractPlugin({
+      filename: '[name].[chunkhash].css',
+    }),
+  ],
+});

--- a/lib/presets.js
+++ b/lib/presets.js
@@ -44,6 +44,18 @@ const webpackDevServerStage = new ConfigPreset({
   searchFilepaths,
 });
 
+const webpackPiral = new ConfigPreset({
+  defaultFilename: 'webpack.piral.config.js',
+  searchFilenames: ['webpack.piral.config.js'],
+  searchFilepaths,
+});
+
+const webpackPilet = new ConfigPreset({
+  defaultFilename: 'webpack.pilet.config.js',
+  searchFilenames: ['webpack.pilet.config.js'],
+  searchFilepaths,
+});
+
 const webpack = new ConfigPreset({
   defaultFilename: 'webpack.prod.config.js',
   searchFilenames: ['webpack.prod.config.js'],
@@ -64,5 +76,7 @@ module.exports = {
   webpackDevServerStage,
   'webpack-dev-server-stage': webpackDevServerStage,
   'webpack-dev-stage': webpackDevServerStage,
+  'webpack-piral': webpackPiral,
+  'webpack-pilet': webpackPilet,
   'webpack-prod': webpack,
 };


### PR DESCRIPTION
This commit adds webpack configurations to support projects being built under [OEP-65](https://github.com/openedx/open-edx-proposals/blob/426f6e09ffe615e77aa9205281d77012385a08d4/oeps/architectural-decisions/oep-XXXX-modular-micro-frontend-domains.rst) (currently still OEP-XXXX). The OEP adds support for [Piral](https://piral.io/) to the open-edX frontend.

The `webpack.piral.config.js` is derived from `webpack.dev.config.js` but removes babel, css and image modules and their configurations as well as the HtmlWebpackPlugin and the devServer (the equivalent functions are handled internally by piral). It is intended to be used with the [`frontend-app-shell`](https://github.com/openedx/frontend-app-shell) package. The shell requires minimal configuration.

The `webpack.pilet.config.js` is derived from `webpack.prod.config.js` though it is intended for use in `development` mode currently. It removes bundle analyzer and adds support for typescript. It also removes the HtmlWebpackPlugin as the piral framework handles that internally. It is intended to be used with future builds of MFE projects being converted to `Pilets` (see Piral.io link above) to be loaded in the `frontend-app-shell` referenced above. 
