### PR TITLE
feat: add JS config handling to webpack and jest configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,12 +217,12 @@ locally. To serve a production build locally:
     attempt to run the build on the same port specified in the
     `env.config.js` file.
 
-## Creating a Production Build with env.config.js (using Tubular)
+## Creating a Production Build with env.config.js
 
 To use a private `env.config.js` file during the production build, the Webpack Production config will look for an env
 variable `process.env.JS_CONFIG_FILEPATH`, which should represent a file path to the desired `env.config.js`.
 
-The only requirement is that the filepath end with `env.config.*`, where either `.js` or `.jsx` as the extension
+The only requirement is that the filepath end with `env.config.*`, with either `.js` or `.jsx` as the extension.
 
     // examples of acceptable filepaths
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ if you need to do this and are running into problems.
 
 ## Local module configuration for Webpack
 
-
 The development webpack configuration allows engineers to create a
 \"module.config.js\" file containing local module overrides. This means
 that if you\'re developing a new feature in a shared library
@@ -217,6 +216,17 @@ locally. To serve a production build locally:
 4.  Run `npm run serve` to serve your production build assets. It will
     attempt to run the build on the same port specified in the
     `env.config.js` file.
+
+## Requiring Jest to reference env.config.js
+
+Jest doesn't rely on webpack to merge the JS-based config into ConfigDocument, so to implement this in your MFE you would need to add it in your MFE's `setupTest.js`
+
+    import envConfig from '../env.config';
+    import mergeConfig from '@edx/frontend-platform';
+
+    ...
+
+    mergeConfig(envConfig);
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -217,9 +217,23 @@ locally. To serve a production build locally:
     attempt to run the build on the same port specified in the
     `env.config.js` file.
 
+## Creating a Production Build with env.config.js (using Tubular)
+
+To use a private `env.config.js` file during the production build, the Webpack Production config will look for an env
+variable `process.env.JS_CONFIG_FILEPATH`, which should represent a file path to the desired `env.config.js`.
+
+The only requirement is that the filepath end with `env.config.*`, where either `.js` or `.jsx` as the extension
+
+    // examples of acceptable filepaths
+
+    JS_CONFIG_FILEPATH="{HOME}/frontends/frontend-app-learner-dashboard/prod.env.config.js"
+
+    JS_CONFIG_FILEPATH="{HOME}/frontends/frontend-app-profile/stage.env.config.jsx"
+
 ## Requiring Jest to reference env.config.js
 
-Jest doesn't rely on webpack to merge the JS-based config into ConfigDocument, so to implement this in your MFE you would need to add it in your MFE's `setupTest.js`
+Jest doesn't rely on Webpack to merge the JS-based config into the Config Document,
+so to ensure Jest is aware of the environment variables in env.config, add the following to the MFE's `setupTest.js`
 
     import envConfig from '../env.config';
     import mergeConfig from '@edx/frontend-platform';

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -4,12 +4,15 @@ const fs = require('fs');
 const presets = require('../lib/presets');
 
 // This assigns the envConfigPath filepath based on whether env.config exists, otherwise it uses the fallback filepath.
+let envConfigPath = path.resolve(__dirname, './jest/fallback.env.config.js');
 const appEnvConfigPathJs = path.resolve(process.cwd(), './env.config.js');
 const appEnvConfigPathJsx = path.resolve(process.cwd(), './env.config.jsx');
 
-const envConfigPath = fs.existsSync(appEnvConfigPathJs) ? appEnvConfigPathJs
-                      : fs.existsSync(appEnvConfigPathJsx) ? appEnvConfigPathJsx
-                      : path.resolve(__dirname, './jest/fallback.env.config.js');
+if (fs.existsSync(appEnvConfigPathJs)) {
+  envConfigPath = appEnvConfigPathJs;
+} else if (fs.existsSync(appEnvConfigPathJsx)) {
+  envConfigPath = appEnvConfigPathJsx;
+};
 
 module.exports = {
   testURL: 'http://localhost/',

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -12,7 +12,7 @@ if (fs.existsSync(appEnvConfigPathJs)) {
   envConfigPath = appEnvConfigPathJs;
 } else if (fs.existsSync(appEnvConfigPathJsx)) {
   envConfigPath = appEnvConfigPathJsx;
-};
+}
 
 module.exports = {
   testURL: 'http://localhost/',

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const presets = require('../lib/presets');
 
 // This assigns the envConfigPath filepath based on whether env.config exists, otherwise it uses the fallback filepath.
+// If both env.config.js and env.config.jsx files exist, then the former will be used to populate the Config Document.
 let envConfigPath = path.resolve(__dirname, './jest/fallback.env.config.js');
 const appEnvConfigPathJs = path.resolve(process.cwd(), './env.config.js');
 const appEnvConfigPathJsx = path.resolve(process.cwd(), './env.config.jsx');

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -3,12 +3,13 @@ const fs = require('fs');
 
 const presets = require('../lib/presets');
 
-let envConfigPath = path.resolve(__dirname, './jest/fallback.env.config.js');
-const appEnvConfigPath = path.resolve(process.cwd(), './env.config.js');
+// This assigns the envConfigPath filepath based on whether env.config exists, otherwise it uses the fallback filepath.
+const appEnvConfigPathJs = path.resolve(process.cwd(), './env.config.js');
+const appEnvConfigPathJsx = path.resolve(process.cwd(), './env.config.jsx');
 
-if (fs.existsSync(appEnvConfigPath)) {
-  envConfigPath = appEnvConfigPath;
-}
+const envConfigPath = fs.existsSync(appEnvConfigPathJs) ? appEnvConfigPathJs
+                      : fs.existsSync(appEnvConfigPathJsx) ? appEnvConfigPathJsx
+                      : path.resolve(__dirname, './jest/fallback.env.config.js');
 
 module.exports = {
   testURL: 'http://localhost/',

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -17,6 +17,14 @@ const presets = require('../lib/presets');
 const resolvePrivateEnvConfig = require('../lib/resolvePrivateEnvConfig');
 const getLocalAliases = require('./getLocalAliases');
 
+// Provides the env.config object that is available in local development so that devserver port number
+// can be assigned below. If no env.config exists (JS or JSX), then it provides an empty object. 
+const envConfigPathJs = path.resolve(process.cwd(),'./env.config.js');
+const envConfigPathJsx = path.resolve(process.cwd(), './env.config.jsx');
+const envConfig = fs.existsSync(envConfigPathJs) ? require(envConfigPathJs)
+                  : fs.existsSync(envConfigPathJsx) ? require(envConfigPathJsx)
+                  : {};
+
 // Add process env vars. Currently used only for setting the
 // server port and the publicPath
 dotenv.config({
@@ -174,7 +182,7 @@ module.exports = merge(commonConfig, {
   // reloading.
   devServer: {
     host: '0.0.0.0',
-    port: process.env.PORT || 8080,
+    port: envConfig.PORT || process.env.PORT || 8080,
     historyApiFallback: {
       index: path.join(PUBLIC_PATH, 'index.html'),
       disableDotRule: true,

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -7,7 +7,6 @@ const Dotenv = require('dotenv-webpack');
 const dotenv = require('dotenv');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
-const fs = require('fs');
 const PostCssAutoprefixerPlugin = require('autoprefixer');
 const PostCssRTLCSS = require('postcss-rtlcss');
 const PostCssCustomMediaCSS = require('postcss-custom-media');
@@ -17,18 +16,6 @@ const commonConfig = require('./webpack.common.config');
 const presets = require('../lib/presets');
 const resolvePrivateEnvConfig = require('../lib/resolvePrivateEnvConfig');
 const getLocalAliases = require('./getLocalAliases');
-
-// Provides the env.config object that is available in local development so that devserver port number
-// can be assigned below. If no env.config exists (JS or JSX), then it provides an empty object.
-let envConfig = {};
-const envConfigPathJs = path.resolve(process.cwd(), './env.config.js');
-const envConfigPathJsx = path.resolve(process.cwd(), './env.config.jsx');
-
-if (fs.existsSync(envConfigPathJs)) {
-  envConfig = require(envConfigPathJs);
-} else if (fs.existsSync(envConfigPathJsx)) {
-  envConfig = require(envConfigPathJsx);
-}
 
 // Add process env vars. Currently used only for setting the
 // server port and the publicPath
@@ -187,7 +174,7 @@ module.exports = merge(commonConfig, {
   // reloading.
   devServer: {
     host: '0.0.0.0',
-    port: envConfig.PORT || process.env.PORT || 8080,
+    port: process.env.PORT || 8080,
     historyApiFallback: {
       index: path.join(PUBLIC_PATH, 'index.html'),
       disableDotRule: true,

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -19,11 +19,15 @@ const getLocalAliases = require('./getLocalAliases');
 
 // Provides the env.config object that is available in local development so that devserver port number
 // can be assigned below. If no env.config exists (JS or JSX), then it provides an empty object. 
+let envConfig = {};
 const envConfigPathJs = path.resolve(process.cwd(),'./env.config.js');
 const envConfigPathJsx = path.resolve(process.cwd(), './env.config.jsx');
-const envConfig = fs.existsSync(envConfigPathJs) ? require(envConfigPathJs)
-                  : fs.existsSync(envConfigPathJsx) ? require(envConfigPathJsx)
-                  : {};
+
+if (fs.existsSync(envConfigPathJs)) {
+  envConfig = require(envConfigPathJs);
+} else if (fs.existsSync(envConfigPathJsx)) {
+  envConfig = require(envConfigPathJsx);
+};
 
 // Add process env vars. Currently used only for setting the
 // server port and the publicPath

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -7,6 +7,7 @@ const Dotenv = require('dotenv-webpack');
 const dotenv = require('dotenv');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const fs = require('fs');
 const PostCssAutoprefixerPlugin = require('autoprefixer');
 const PostCssRTLCSS = require('postcss-rtlcss');
 const PostCssCustomMediaCSS = require('postcss-custom-media');

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -19,16 +19,16 @@ const resolvePrivateEnvConfig = require('../lib/resolvePrivateEnvConfig');
 const getLocalAliases = require('./getLocalAliases');
 
 // Provides the env.config object that is available in local development so that devserver port number
-// can be assigned below. If no env.config exists (JS or JSX), then it provides an empty object. 
+// can be assigned below. If no env.config exists (JS or JSX), then it provides an empty object.
 let envConfig = {};
-const envConfigPathJs = path.resolve(process.cwd(),'./env.config.js');
+const envConfigPathJs = path.resolve(process.cwd(), './env.config.js');
 const envConfigPathJsx = path.resolve(process.cwd(), './env.config.jsx');
 
 if (fs.existsSync(envConfigPathJs)) {
   envConfig = require(envConfigPathJs);
 } else if (fs.existsSync(envConfigPathJsx)) {
   envConfig = require(envConfigPathJsx);
-};
+}
 
 // Add process env vars. Currently used only for setting the
 // server port and the publicPath

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -23,6 +23,23 @@ const HtmlWebpackNewRelicPlugin = require('../lib/plugins/html-webpack-new-relic
 const commonConfig = require('./webpack.common.config');
 const presets = require('../lib/presets');
 
+/** This condition confirms whether the MFE has a JS-based configuration file and creates a copy of the file based
+ * on the filepath given. If the environment variable exists, then an env.config.js(x) file will be created at the root
+ * directory and its env variables can be accessed with getConfig().
+ *
+ * https://github.com/openedx/frontend-build/blob/master/docs/0002-js-environment-config.md
+ * https://github.com/openedx/frontend-platform/blob/master/docs/decisions/0007-javascript-file-configuration.rst
+ */
+const envConfigPath = process.env.JS_CONFIG_FILEPATH;
+if (envConfigPath) {
+  // This handles the possibility that env.config will have either a JS or JSX extension
+  const envConfigFilename = envConfigPath.slice(envConfigPath.indexOf('env.config'));
+
+  fs.copyFile(process.env.JS_CONFIG_FILEPATH, envConfigFilename, (err) => {
+    if (err) { throw err; }
+  });
+}
+
 // Add process env vars. Currently used only for setting the PUBLIC_PATH.
 dotenv.config({
   path: path.resolve(process.cwd(), '.env'),

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -39,9 +39,9 @@ if (envConfigPath) {
   const envConfigFilename = envConfigPath.slice(envConfigPath.indexOf('env.config'));
   fs.copyFileSync(envConfigPath, envConfigFilename);
 
-  let newConfigFilepath = path.resolve(process.cwd(), envConfigFilename);
+  const newConfigFilepath = path.resolve(process.cwd(), envConfigFilename);
   envConfig = require(newConfigFilepath);
-};
+}
 
 // Add process env vars. Currently used only for setting the PUBLIC_PATH.
 dotenv.config({

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -24,22 +24,24 @@ const HtmlWebpackNewRelicPlugin = require('../lib/plugins/html-webpack-new-relic
 const commonConfig = require('./webpack.common.config');
 const presets = require('../lib/presets');
 
-/** This condition confirms whether the MFE has a JS-based configuration file and creates a copy of the file based
- * on the filepath given. If the environment variable exists, then an env.config.js(x) file will be created at the root
- * directory and its env variables can be accessed with getConfig().
+/** This condition confirms whether the configuration for the MFE has switched to a JS-based configuration
+ * as previously implemented in frontend-build and frontend-platform. If the environment variable exists, then
+ * an env.config.js file will be created at the root directory and its env variables can be accessed with getConfig().
  *
  * https://github.com/openedx/frontend-build/blob/master/docs/0002-js-environment-config.md
  * https://github.com/openedx/frontend-platform/blob/master/docs/decisions/0007-javascript-file-configuration.rst
  */
-const envConfigPath = process.env.JS_CONFIG_FILEPATH;
-if (envConfigPath) {
-  // This handles the possibility that env.config will have either a JS or JSX extension
-  const envConfigFilename = envConfigPath.slice(envConfigPath.indexOf('env.config'));
 
-  fs.copyFile(envConfigPath, envConfigFilename, (err) => {
-    if (err) { throw err; }
-  });
-}
+const envConfigPath = process.env.JS_CONFIG_FILEPATH;
+let envConfig = {};
+
+if (envConfigPath) {
+  const envConfigFilename = envConfigPath.slice(envConfigPath.indexOf('env.config'));
+  fs.copyFileSync(envConfigPath, envConfigFilename);
+
+  let newConfigFilepath = path.resolve(process.cwd(), envConfigFilename);
+  envConfig = require(newConfigFilepath);
+};
 
 // Add process env vars. Currently used only for setting the PUBLIC_PATH.
 dotenv.config({
@@ -63,12 +65,12 @@ if (process.env.ENABLE_NEW_RELIC !== 'false') {
     agentID: process.env.NEW_RELIC_AGENT_ID || 'undefined_agent_id',
     trustKey: process.env.NEW_RELIC_TRUST_KEY || 'undefined_trust_key',
     licenseKey: process.env.NEW_RELIC_LICENSE_KEY || 'undefined_license_key',
-    applicationID: process.env.NEW_RELIC_APP_ID || 'undefined_application_id',
+    applicationID: envConfig.NEW_RELIC_APP_ID || process.env.NEW_RELIC_APP_ID || 'undefined_application_id',
   }));
   extraPlugins.push(new NewRelicSourceMapPlugin({
-    applicationId: process.env.NEW_RELIC_APP_ID,
+    applicationId: envConfig.NEW_RELIC_APP_ID || process.env.NEW_RELIC_APP_ID,
     apiKey: process.env.NEW_RELIC_ADMIN_KEY,
-    staticAssetUrl: process.env.BASE_URL,
+    staticAssetUrl: envConfig.BASE_URL || process.env.BASE_URL,
     // upload source maps in prod builds only
     noop: typeof process.env.NEW_RELIC_ADMIN_KEY === 'undefined',
   }));

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -12,6 +12,7 @@ const NewRelicSourceMapPlugin = require('@edx/new-relic-source-map-webpack-plugi
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
+const fs = require('fs');
 const PostCssAutoprefixerPlugin = require('autoprefixer');
 const PostCssRTLCSS = require('postcss-rtlcss');
 const PostCssCustomMediaCSS = require('postcss-custom-media');
@@ -35,7 +36,7 @@ if (envConfigPath) {
   // This handles the possibility that env.config will have either a JS or JSX extension
   const envConfigFilename = envConfigPath.slice(envConfigPath.indexOf('env.config'));
 
-  fs.copyFile(process.env.JS_CONFIG_FILEPATH, envConfigFilename, (err) => {
+  fs.copyFile(envConfigPath, envConfigFilename, (err) => {
     if (err) { throw err; }
   });
 }

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -26,8 +26,9 @@ const presets = require('../lib/presets');
 
 /**
  * This condition confirms whether the configuration for the MFE has switched to a JS-based configuration
- * as previously implemented in frontend-build and frontend-platform. If the environment variable JS_CONFIG_FILEPATH exists, then
- * an env.config.js(x) file will be created at the root directory and its env variables can be accessed with getConfig().
+ * as previously implemented in frontend-build and frontend-platform. If the environment variable JS_CONFIG_FILEPATH
+ * exists, then an env.config.js(x) file will be copied from the location referenced by the environment variable to the
+ * root directory. Its env variables can be accessed with getConfig().
  *
  * https://github.com/openedx/frontend-build/blob/master/docs/0002-js-environment-config.md
  * https://github.com/openedx/frontend-platform/blob/master/docs/decisions/0007-javascript-file-configuration.rst

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -24,23 +24,20 @@ const HtmlWebpackNewRelicPlugin = require('../lib/plugins/html-webpack-new-relic
 const commonConfig = require('./webpack.common.config');
 const presets = require('../lib/presets');
 
-/** This condition confirms whether the configuration for the MFE has switched to a JS-based configuration
- * as previously implemented in frontend-build and frontend-platform. If the environment variable exists, then
- * an env.config.js file will be created at the root directory and its env variables can be accessed with getConfig().
+/**
+ * This condition confirms whether the configuration for the MFE has switched to a JS-based configuration
+ * as previously implemented in frontend-build and frontend-platform. If the environment variable JS_CONFIG_FILEPATH exists, then
+ * an env.config.js(x) file will be created at the root directory and its env variables can be accessed with getConfig().
  *
  * https://github.com/openedx/frontend-build/blob/master/docs/0002-js-environment-config.md
  * https://github.com/openedx/frontend-platform/blob/master/docs/decisions/0007-javascript-file-configuration.rst
  */
 
 const envConfigPath = process.env.JS_CONFIG_FILEPATH;
-let envConfig = {};
 
 if (envConfigPath) {
   const envConfigFilename = envConfigPath.slice(envConfigPath.indexOf('env.config'));
   fs.copyFileSync(envConfigPath, envConfigFilename);
-
-  const newConfigFilepath = path.resolve(process.cwd(), envConfigFilename);
-  envConfig = require(newConfigFilepath);
 }
 
 // Add process env vars. Currently used only for setting the PUBLIC_PATH.
@@ -65,12 +62,12 @@ if (process.env.ENABLE_NEW_RELIC !== 'false') {
     agentID: process.env.NEW_RELIC_AGENT_ID || 'undefined_agent_id',
     trustKey: process.env.NEW_RELIC_TRUST_KEY || 'undefined_trust_key',
     licenseKey: process.env.NEW_RELIC_LICENSE_KEY || 'undefined_license_key',
-    applicationID: envConfig.NEW_RELIC_APP_ID || process.env.NEW_RELIC_APP_ID || 'undefined_application_id',
+    applicationID: process.env.NEW_RELIC_APP_ID || 'undefined_application_id',
   }));
   extraPlugins.push(new NewRelicSourceMapPlugin({
-    applicationId: envConfig.NEW_RELIC_APP_ID || process.env.NEW_RELIC_APP_ID,
+    applicationId: process.env.NEW_RELIC_APP_ID,
     apiKey: process.env.NEW_RELIC_ADMIN_KEY,
-    staticAssetUrl: envConfig.BASE_URL || process.env.BASE_URL,
+    staticAssetUrl: process.env.BASE_URL,
     // upload source maps in prod builds only
     noop: typeof process.env.NEW_RELIC_ADMIN_KEY === 'undefined',
   }));


### PR DESCRIPTION
This PR includes the following changes: 
- JS-based configuration is made available to Webpack Prod by passing in an environment variable
- Webpack Dev config can now use the `PORT` assigned in `env.config.js`. Otherwise checks `process.env.PORT` or falls back to 8080.
- Jest config now searches for either `env.config.js` or `env.config.jsx` for environment variables. 
- updated README to provide steps for using JS config in production and testing. 


Resolves issues #513 and #514 
