### PR TITLE
fix: bump shared eslint config version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@babel/plugin-syntax-dynamic-import": "7.8.3",
         "@babel/preset-env": "7.24.7",
         "@babel/preset-react": "7.24.7",
-        "@edx/eslint-config": "4.0.0",
+        "@edx/eslint-config": "4.1.0",
         "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
         "@edx/typescript-config": "1.0.1",
         "@formatjs/cli": "^6.0.3",
@@ -2215,9 +2215,9 @@
       }
     },
     "node_modules/@edx/eslint-config": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-4.0.0.tgz",
-      "integrity": "sha512-KApsfwmgdH2dbs7ZuxaSumUNTheo4bvvijvda1rkhCYDN0u4HMxsM8zOUq+BF6AjBb67odHut7WYbgc4gRPPGA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-4.1.0.tgz",
+      "integrity": "sha512-PHXQFI8yFJ15wLni2KUsejcZlyY41zcNQNLVw8gtOBW4+1XrLAat1p+d7/tBp2qrPzulh+NDVO4DWiPgRJ4Y2Q==",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/preset-env": "7.24.7",
     "@babel/preset-react": "7.24.7",
-    "@edx/eslint-config": "4.0.0",
+    "@edx/eslint-config": "4.1.0",
     "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
     "@edx/typescript-config": "1.0.1",
     "@formatjs/cli": "^6.0.3",


### PR DESCRIPTION
The shared `@edx/eslint-config` was recently updated to support the `es2020` environment such that syntax like `globalThis` won't cause linting errors.

This PR bumps the version of `@edx/eslint-config` to pull in this change for consuming MFEs and shared JS libraries (e.g., frontend-platform).