### PR TITLE
build: Add structured Maintainers information

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,13 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'frontend-build'
+  description: "Common build scripts and tooling for Open edX micro-frontends."
+  annotations:
+    openedx.org/arch-interest-groups: ""
+spec:
+  owner: group:committers-frontend-build
+  type: 'library'
+  lifecycle: 'production'


### PR DESCRIPTION
This PR adds the `catalog-info.yaml` file for backstage.
