### PR TITLE
fix: add typescript files to coverage report

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
     'env.config': envConfigPath,
   },
   collectCoverageFrom: [
-    'src/**/*.{js,jsx}',
+    'src/**/*.{js,jsx,ts,tsx}',
   ],
   coveragePathIgnorePatterns: [
     '/node_modules/',


### PR DESCRIPTION
## Description
Currently, `ts` and `tsx` files are not included in the coverage report. This PR updates the `collectCoverageFrom` param from `jest.config` to fix the issue.

## More information
[Here](https://github.com/openedx/frontend-app-course-authoring/pull/1155) is a `course-autoring` PR using a version with this change and the coverage report [including ts files](https://app.codecov.io/gh/openedx/frontend-app-course-authoring/commit/e99a176adf50d15662a3c711ed836ad79af35ccc/indirect-changes?dropdown=coverage&el=desc&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr%20comments&utm_term=openedx).
