### PR TITLE
fix: upgrade @edx/typescript-config to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/preset-react": "7.24.7",
         "@edx/eslint-config": "4.1.0",
         "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
-        "@edx/typescript-config": "1.0.1",
+        "@edx/typescript-config": "1.1.0",
         "@formatjs/cli": "^6.0.3",
         "@fullhuman/postcss-purgecss": "5.0.0",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
@@ -2239,9 +2239,9 @@
       }
     },
     "node_modules/@edx/typescript-config": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/typescript-config/-/typescript-config-1.0.1.tgz",
-      "integrity": "sha512-w0g3nIX9oEch8Rip8q8sb/nrurGEHA1BEjK/I1LAQwA44K4FPMWvyvabmZErrdTJ9sXcZL10aWD3bat1obV8Bg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/typescript-config/-/typescript-config-1.1.0.tgz",
+      "integrity": "sha512-HF+7dsSgA2YQ6f/qV4HnrEYBoIhIdxVQZgDyYk/YGvaVGqT6IFuaHnYUP7ImpCUMOUmx/Jl7EyuVeaMe2LrMcA==",
       "peerDependencies": {
         "typescript": "^4.9.4"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/preset-react": "7.24.7",
     "@edx/eslint-config": "4.1.0",
     "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
-    "@edx/typescript-config": "1.0.1",
+    "@edx/typescript-config": "1.1.0",
     "@formatjs/cli": "^6.0.3",
     "@fullhuman/postcss-purgecss": "5.0.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.15",


### PR DESCRIPTION
Upgrades `@edx/typescript-config` to latest version (1.1.0) to pull in recent updates introduced by https://github.com/openedx/typescript-config/pull/12.

Issues and resolutions:

* `.tsx` files need to import `React` global; migrates to new JSX transform for parity with `.jsx` files, where `React` import is no longer needed.
* Later/modern JS syntax like `.replaceAll()` not supported; updates lib to include "ESNext" (matches create-react-app's TS config and @davidjoy frontend-base).
* Dynamic imports not supported; migrates to module: "ESNext"