### PR TITLE
fix: ignore node_modules path for jest watchman

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -45,4 +45,7 @@ module.exports = {
     ],
     ...tsjPreset.transform,
   },
+  watchPathIgnorePatterns: [
+    '/node_modules/',
+  ],
 };


### PR DESCRIPTION
When attempting to run a Jest test with the `watch` flag, (Ex. `npm run test:watch`) within the `frontend-app-admin-portal` repository, I ran into an issue where the Jest watch would not initiate and would trigger the following error:

<img width="946" alt="Screenshot 2024-09-22 at 12 21 05 AM" src="https://github.com/user-attachments/assets/4339dcea-3076-4c64-b285-281c5053af7f">

Adding the configuration field `watchPathIgnorePatterns` to the jest config file to ignore the node modules directory when running a Jest watch. The inclusion of this field resolved the error locally as an override field in `jest.config.js`, but I am proposing to add it within `frontend-build`'s `jest.config.js` configuration directly.
