### PR TITLE
feat: allow setting robots content attribute through config

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -160,7 +160,7 @@ module.exports = merge(commonConfig, {
       chunks: ['app'],
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
-      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Configures "content" value of a "robots" meta tag
+      META_TAG_ROBOTS_CONTENT_ATTR: process.env.META_TAG_ROBOTS_CONTENT_ATTR || null,
       NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({

--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -160,6 +160,7 @@ module.exports = merge(commonConfig, {
       chunks: ['app'],
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
+      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Allows configuring "content" attribute value of a "robots" meta tag
       NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({

--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -160,7 +160,7 @@ module.exports = merge(commonConfig, {
       chunks: ['app'],
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
-      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Allows configuring "content" attribute value of a "robots" meta tag
+      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Configures "content" value of a "robots" meta tag
       NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -184,6 +184,7 @@ module.exports = merge(commonConfig, {
       chunks: ['app'],
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
+      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Allows configuring "content" attribute value of a "robots" meta tag
       NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -184,7 +184,7 @@ module.exports = merge(commonConfig, {
       chunks: ['app'],
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
-      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Configures "content" value of a "robots" meta tag
+      META_TAG_ROBOTS_CONTENT_ATTR: process.env.META_TAG_ROBOTS_CONTENT_ATTR || null,
       NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -184,7 +184,7 @@ module.exports = merge(commonConfig, {
       chunks: ['app'],
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
-      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Allows configuring "content" attribute value of a "robots" meta tag
+      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Configures "content" value of a "robots" meta tag
       NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -205,7 +205,7 @@ module.exports = merge(commonConfig, {
       chunks: ['app'],
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
-      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Configures "content" value of a "robots" meta tag
+      META_TAG_ROBOTS_CONTENT_ATTR: process.env.META_TAG_ROBOTS_CONTENT_ATTR || null,
       NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -205,7 +205,7 @@ module.exports = merge(commonConfig, {
       chunks: ['app'],
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
-      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Allows configuring "content" attribute value of a "robots" meta tag
+      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Configures "content" value of a "robots" meta tag
       NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -205,6 +205,7 @@ module.exports = merge(commonConfig, {
       chunks: ['app'],
       FAVICON_URL: process.env.FAVICON_URL || null,
       OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
+      ROBOT_CONTENT_TAG: process.env.ROBOT_CONTENT_TAG || null, // Allows configuring "content" attribute value of a "robots" meta tag
       NODE_ENV: process.env.NODE_ENV || null,
     }),
     new Dotenv({


### PR DESCRIPTION
Enable config-based setting of `<meta name="robots" content="{value}">` tag to allow MFEs to instruct search crawlers / indexers how to handle their content.

Related PRs:
- https://github.com/openedx/frontend-app-learning/pull/1520

See also:
- [Robots meta tag reference](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)
- [AU-2285](https://2u-internal.atlassian.net/browse/AU-2285)