### PR TITLE
fix: ensure TsconfigPathsPlugin is only added if tsconfig.json exists

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
@@ -11,6 +12,14 @@ const {
 
 const paragonThemeCss = getParagonThemeCss(process.cwd());
 const brandThemeCss = getParagonThemeCss(process.cwd(), { isBrandOverride: true });
+
+const tsconfigPath = path.resolve(process.cwd(), 'tsconfig.json');
+const resolvePlugins = [];
+
+// Conditionally add TsconfigPathsPlugin if tsconfig.json exists
+if (fs.existsSync(tsconfigPath)) {
+  resolvePlugins.push(new TsconfigPathsPlugin({ configFile: tsconfigPath }));
+}
 
 module.exports = {
   entry: {
@@ -46,9 +55,7 @@ module.exports = {
       'env.config': false,
     },
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
-    plugins: [
-      new TsconfigPathsPlugin(),
-    ],
+    plugins: resolvePlugins,
   },
   optimization: {
     splitChunks: {

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from '@/App';
+import App from '@src/App';
 
 // This line is to emulate what frontend-platform does when i18n initializes.
 // It's necessary because our stylesheet is generated with `[dir="ltr"]` as a prefix on all

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": ".",
     "outDir": "dist",
     "paths": {
-      "@/*": ["./src/*"]
+      "@src/*": ["./src/*"]
     },
   },
   "include": [


### PR DESCRIPTION
The release of 14.4.0 to make Webpack and ESlint aware of `paths` defined in `tsconfig.json` breaks MFEs that have not yet adopted TypeScript, as described [here](https://github.com/openedx/frontend-build/pull/636#issuecomment-2760211733). If a project does't define `tsconfig.json`, `tsconfig-paths-webpack-plugin` will unexpectedly throw an error due to the missing file.

```shell
> @edx/frontend-app-learner-dashboard@0.0.1 build
> fedx-scripts webpack

Running with resolved config:
/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/webpack.prod.config.js

[webpack-cli] Failed to load '/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/webpack.prod.config.js' config
[webpack-cli] Error: ENOENT: no such file or directory, stat 'tsconfig.json'
    at Object.statSync (node:fs:1[6](https://github.com/openedx/frontend-app-learner-dashboard/actions/runs/14122223957/job/39564410662?pr=569#step:8:7)67:25)
    at resolveConfigPath (/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths/lib/tsconfig-loader.js:56:12)
    at loadSyncDefault (/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths/lib/tsconfig-loader.js:33:22)
    at tsConfigLoader (/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths/lib/tsconfig-loader.js:2[7](https://github.com/openedx/frontend-app-learner-dashboard/actions/runs/14122223957/job/39564410662?pr=569#step:8:8):22)
    at configLoader (/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths/lib/config-loader.js:2[8](https://github.com/openedx/frontend-app-learner-dashboard/actions/runs/14122223957/job/39564410662?pr=569#step:8:9):22)
    at Object.loadConfig (/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths/lib/config-loader.js:8:12)
    at loadConfig (/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/node_modules/tsconfig-paths-webpack-plugin/lib/plugin.js:86:36)
    at new TsconfigPathsPlugin (/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/node_modules/tsconfig-paths-webpack-plugin/lib/plugin.js:35:26)
    at Object.<anonymous> (/home/runner/work/frontend-app-learner-dashboard/frontend-app-learner-dashboard/node_modules/@openedx/frontend-build/config/webpack.common.config.js:50:7)
    at Module._compile (node:internal/modules/cjs/loader:152[9](https://github.com/openedx/frontend-app-learner-dashboard/actions/runs/14122223957/job/39564410662?pr=569#step:8:10):14) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: 'tsconfig.json'
}
```

This PR ensures `tsconfig-paths-webpack-plugin` is only included in `webpack.common.config.js` if a root `tsconfig.json` file exists for a project.

### Testing Instructions

1. Run `npm run build` for the example MFE app included with this project with the included `./example/tsconfig.json` file.
2. Observe it builds successfully.
3. Temporarily delete the `./example/tsconfig.json` file, and change the `@src/App` import to `./App`.
4. Re-run `npm run build` for the example MFE.
5. Observe it will now build successfully; previously, it would not.