### PR TITLE
feat: lighter build by rewriting lodash imports

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -12,8 +12,12 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-syntax-dynamic-import',
     [
+      // Prevent importing large libraries by rewriting imports
+      // Eventually, we should add 'preventFullImport": true' to each of these imports,
+      // to prevent developers from committing full imports.
       'transform-imports',
       {
+        // fortawesome
         '@fortawesome/free-brands-svg-icons': {
           transform: '@fortawesome/free-brands-svg-icons/${member}',
           skipDefaultConversion: true,
@@ -24,6 +28,11 @@ module.exports = {
         },
         '@fortawesome/free-solid-svg-icons': {
           transform: '@fortawesome/free-solid-svg-icons/${member}',
+          skipDefaultConversion: true,
+        },
+        // lodash
+        lodash: {
+          transform: 'lodash/${member}',
           skipDefaultConversion: true,
         },
       },


### PR DESCRIPTION
Incorrect lodash imports are causing MFEs to import the entire lodash library. This change shaves off a few kB of every MFE compressed build.