### PR TITLE
fix: configure `PostCssAutoprefixerPlugin` to not remove vendor prefixes

### DIFF
--- a/config/webpack.dev-stage.config.js
+++ b/config/webpack.dev-stage.config.js
@@ -83,7 +83,9 @@ module.exports = merge(commonConfig, {
             options: {
               postcssOptions: {
                 plugins: [
-                  PostCssAutoprefixerPlugin(),
+                  PostCssAutoprefixerPlugin({
+                    remove: false, // Prevents removing vendor prefixes
+                  }),
                   PostCssRTLCSS(),
                   PostCssCustomMediaCSS(),
                 ],

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -47,7 +47,9 @@ function getStyleUseConfig() {
       options: {
         postcssOptions: {
           plugins: [
-            PostCssAutoprefixerPlugin(),
+            PostCssAutoprefixerPlugin({
+              remove: false, // Prevents removing vendor prefixes
+            }),
             PostCssRTLCSS(),
             PostCssCustomMediaCSS(),
           ],

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -112,7 +112,9 @@ module.exports = merge(commonConfig, {
             options: {
               postcssOptions: {
                 plugins: [
-                  PostCssAutoprefixerPlugin(),
+                  PostCssAutoprefixerPlugin({
+                    remove: false, // Prevents removing vendor prefixes
+                  }),
                   PostCssRTLCSS(),
                   PostCssCustomMediaCSS(),
                   CssNano(),


### PR DESCRIPTION
Resolves https://github.com/openedx/paragon/issues/3514