### PR TITLE
feat(formatjs): support additional src folders

### DIFF
--- a/bin/fedx-scripts.js
+++ b/bin/fedx-scripts.js
@@ -69,8 +69,12 @@ switch (commandName) {
     require('webpack-dev-server/bin/webpack-dev-server');
     break;
   case 'formatjs': {
-    // To extract more messages on other source folders use:
-    // --include=plugins --include=plugins2
+    // The include option is used to specify which additional source folders to extract messages from.
+    // To extract more messages on other source folders use: --include=plugins --include=plugins2
+    // The intention use case is to allow extraction from the 'plugins' directory on 'frontend-app-authoring'.
+    // That plugins folder were kept outside the src folder to ensure they remain independent and
+    // can function without relying on the MFE environment's special features.
+    // This approach allows them to be packaged separately as NPM packages.
     const additionalSrcFolders = [];
     process.argv.forEach((val, index) => {
       // if val starts with --include= then add the value to additionalSrcFolders

--- a/bin/fedx-scripts.js
+++ b/bin/fedx-scripts.js
@@ -88,8 +88,9 @@ switch (commandName) {
     const commonArgs = [
       '--format', 'node_modules/@openedx/frontend-build/lib/formatter.js',
       '--ignore', `${srcFoldersString}/**/*.json`,
+      '--ignore', `${srcFoldersString}/**/*.d.ts`,
       '--out-file', './temp/babel-plugin-formatjs/Default.messages.json',
-      '--', `${srcFoldersString}/**/*.js*`,
+      '--', `${srcFoldersString}/**/*.{j,t}s*`,
     ];
     process.argv = process.argv.concat(commonArgs);
     ensureConfigOption(presets.formatjs);

--- a/bin/fedx-scripts.js
+++ b/bin/fedx-scripts.js
@@ -69,11 +69,27 @@ switch (commandName) {
     require('webpack-dev-server/bin/webpack-dev-server');
     break;
   case 'formatjs': {
+    // To extract more messages on other source folders use:
+    // --include=plugins --include=plugins2
+    const additionalSrcFolders = [];
+    process.argv.forEach((val, index) => {
+      // if val starts with --include= then add the value to additionalSrcFolders
+      if (val.startsWith('--include=')) {
+        additionalSrcFolders.push(val.split('=')[1]);
+        // remove the value from process.argv
+        process.argv.splice(index, 1);
+      }
+    });
+    const srcFolders = ['src'].concat(additionalSrcFolders);
+    let srcFoldersString = srcFolders.join(',');
+    if (srcFolders.length > 1) {
+      srcFoldersString = `{${srcFoldersString}}`;
+    }
     const commonArgs = [
       '--format', 'node_modules/@openedx/frontend-build/lib/formatter.js',
-      '--ignore', 'src/**/*.json',
+      '--ignore', `${srcFoldersString}/**/*.json`,
       '--out-file', './temp/babel-plugin-formatjs/Default.messages.json',
-      '--', 'src/**/*.js*',
+      '--', `${srcFoldersString}/**/*.js*`,
     ];
     process.argv = process.argv.concat(commonArgs);
     ensureConfigOption(presets.formatjs);


### PR DESCRIPTION
Enhance the `fedx-scripts.js` script on `formatjs` with an option to extract translations on additional source folders.

Example:
`--include=plugins --include=plugins2`

This PR is required to fix the extraction process on the https://github.com/openedx/frontend-app-authoring/ because there are an additional [`plugins` source folder](https://github.com/openedx/frontend-app-authoring/tree/master/plugins/course-apps).

Then the next step is to change the `i18n_extract` on package.json to include the additional folder on https://github.com/openedx/frontend-app-authoring/blob/04faf54ad8ca74a288c872f1140eafc0aa4f9763/package.json#L14

From:
```json
"i18n_extract": "fedx-scripts formatjs extract",
```

To:
```json
"i18n_extract": "fedx-scripts formatjs extract --include=plugins",
```

Additionally it was added a new commit to extract translations from `.ts` files.

## Additional information
https://github.com/openedx/frontend-app-authoring/pull/1589