### PR TITLE
fix: remove skipDefaultConversion for lodash transform import

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -33,7 +33,6 @@ module.exports = {
         // lodash
         lodash: {
           transform: 'lodash/${member}',
-          skipDefaultConversion: true,
         },
       },
     ],


### PR DESCRIPTION
This PR aims to fix https://github.com/openedx/frontend-build/pull/645#discussion_r2143800882 